### PR TITLE
rudimentary tasting notes update/create

### DIFF
--- a/src/components/forms/CoffeeForm.js
+++ b/src/components/forms/CoffeeForm.js
@@ -38,8 +38,7 @@ export default function CoffeeForm({ obj = initialState }) {
     const { name, value } = e.target;
     // Check if the field being checked is tasting notes and convert the value to an array if so
     if (name === 'tastingNotes') {
-      const notesArr = [];
-      notesArr.push(value);
+      const notesArr = value.split(',');
       setFormInput((prevState) => ({
         ...prevState,
         tastingNotes: notesArr,
@@ -121,8 +120,8 @@ export default function CoffeeForm({ obj = initialState }) {
 
       {/* tasting notes */}
       {/* TODO: Handle input for more than one tasting note */}
-      <FloatingLabel controlId="floatingInput7" label="Tasting Notes">
-        <Form.Control type="text" placeholder="Tasting Notes" name="tastingNotes" value={formInput.tastingNotes} onChange={handleChange} />
+      <FloatingLabel controlId="floatingInput7" label="tasting notes (separated by commas)">
+        <Form.Control type="text" placeholder="tasting notes (separated by commas)" name="tastingNotes" value={formInput.tastingNotes} onChange={handleChange} />
       </FloatingLabel>
 
       {/* purchase location */}


### PR DESCRIPTION
## Description
Functionality now exists to add tasting notes as an array to any coffee object, separated by commas

## Related Issue
#3 #4 

## Motivation and Context
All properties on coffee objects are now fully createable, readable, updateable

## How Can This Be Tested?
Click edit on a coffee object or +add and fill out the form. On the tasting notes field, enter however many tasting notes there should be, separated by commas. 

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
